### PR TITLE
Bump clsx to ^2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^1.2.1",
+        "clsx": "^2.1.1",
         "d3-path": "^3.1.0"
       },
       "devDependencies": {
@@ -2536,6 +2536,16 @@
         "@types/react": "*",
         "react": ">= 16.8.6",
         "react-dom": ">= 16.8.6"
+      }
+    },
+    "node_modules/@design-systems/utils/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@devtools-ds/object-inspector": {
@@ -15957,9 +15967,10 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -36662,6 +36673,14 @@
         "clsx": "^1.0.4",
         "focus-lock": "^0.8.0",
         "react-merge-refs": "^1.0.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+          "dev": true
+        }
       }
     },
     "@devtools-ds/object-inspector": {
@@ -46669,9 +46688,9 @@
       }
     },
     "clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "co": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-dom": ">=18"
   },
   "dependencies": {
-    "clsx": "^1.2.1",
+    "clsx": "^2.1.1",
     "d3-path": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The only consumer-visible outdated dependency ahead of the 1.0.0 publish. clsx 2 is API-identical for our usage (`clsx(string, { ... })`); a `^2` range lets consumers dedupe with their own clsx 2 install, and v2 ships a proper ESM exports map.

Verified after the bump:
- `dist/index.mjs` unchanged (clsx is externalized in the library build)
- Legacy IIFE bundle (which embeds clsx) renders a DOM byte-identical to the CRA baseline (hash-compared), hover info bubble + marker still work
- Typecheck + both builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)