### PR TITLE
Release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "andys-charts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "andys-charts",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "andys-charts",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "A simple charting library visualizing plays per day for musical tracks, made out of React, TypeScript and SVG.",
 	"author": "Andy Graulund <andy@graulund.com>",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- bumps `andys-charts` from 1.0.0 to 1.1.0
- prepares the completed modernization work for npm publication
- keeps package metadata and the lockfile version in sync

## Why

This is a backward-compatible minor release containing the modernization,
robustness, accessibility, packaging, and test improvements already merged into
`main`.

## Validation

- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run coverage` — 31 tests passed, 95.57% line coverage, 100% function coverage
- `npm run test:browser` — 8 Chromium tests passed
- `npm run build`
- `npm run test:package`

After this PR is merged, tag the merge commit as `v1.1.0`. The tag matches the
repository's publish workflow trigger.
